### PR TITLE
Update ads.js

### DIFF
--- a/lib/ads.js
+++ b/lib/ads.js
@@ -74,12 +74,19 @@ var getAdsObject = function (options) {
   ads.adsClient.notify = function (handle, cb) {
     return notify.call(ads, handle, cb)
   }
+
+  ads.adsClient.releaseNotificationHandles = function (cb) {
+    return releaseNotificationHandles.call(ads, cb)
+  }
+	
   ads.adsClient.writeRead = function (handle, cb) {
     return writeReadCommand.call(ads, handle, cb)
   }
+	
   ads.adsClient.getSymbols = function (cb, raw) {
     return getSymbols.call(ads, cb, raw)
   }
+	
   ads.adsClient.getDatatyps = function (cb) {
     return getDatatyps.call(ads, cb)
   }


### PR DESCRIPTION
Exposed the releaseNotificationHandles to clean up the Notification Handler from outside the Package.

Related to Issue #3 